### PR TITLE
Updated class to cater for foreground (transparent shadow overlay) on bu...

### DIFF
--- a/Classes/MHRotaryKnob.h
+++ b/Classes/MHRotaryKnob.h
@@ -70,6 +70,7 @@ MHRotaryKnobInteractionStyle;
 {
 	UIImageView* backgroundImageView;  ///< shows the background image
 	UIImageView* knobImageView;        ///< shows the knob image
+	UIImageView* foregroundImageView;  /// foreground image (i.e. shadow transparency overlay)	
 	UIImage* knobImageNormal;          ///< knob image for normal state
 	UIImage* knobImageHighlighted;     ///< knob image for highlighted state
 	UIImage* knobImageDisabled;        ///< knob image for disabled state
@@ -83,6 +84,9 @@ MHRotaryKnobInteractionStyle;
 
 /*! The image that is drawn behind the knob. May be nil. */
 @property (nonatomic, retain) UIImage* backgroundImage;
+
+/*! The image that is drawn in front of the knob. May be nil. */
+@property (nonatomic, strong) UIImage* foregroundImage;
 
 /*! The image currently being used to draw the knob. */
 @property (nonatomic, retain, readonly) UIImage* currentKnobImage;


### PR DESCRIPTION
Hi, I have edited my copy of the class to allow for a foreground image as well.

My button images actually comprise of 3 layers - the background, the button itself and an overlay over the top to provide a 'shadow' effect.

The changes here work fine when I tested.  They may be useful in the main branch for future users...?

Thanks,
Devan
